### PR TITLE
chore: fix repo url in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://storybook.js.org/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/storybookjs/eslint-config.git"
+    "url": "https://github.com/storybookjs/linter-config.git"
   },
   "license": "ISC",
   "author": "Norbert de Langen",


### PR DESCRIPTION
This URL is used in NPM registry: https://www.npmjs.com/package/@storybook/linter-config